### PR TITLE
Fix CyclesSinceLastPurchase calculation

### DIFF
--- a/jstark/features/__init__.py
+++ b/jstark/features/__init__.py
@@ -15,7 +15,7 @@ from .min_gross_spend import MinGrossSpend
 from .max_gross_spend import MaxGrossSpend
 from .min_net_spend import MinNetSpend
 from .max_net_spend import MaxNetSpend
-from .average_gross_spend_per_basket import AverageGrossSpendPerBasket
+from .average_gross_spend_per_basket import AvgGrossSpendPerBasket
 from .quantity import Quantity
 from .average_quantity_per_basket import AvgQuantityPerBasket
 from .most_recent_purchase_date import MostRecentPurchaseDate
@@ -36,7 +36,7 @@ from .recency_weighted_basket import (
     RecencyWeightedApproxBasket95,
     RecencyWeightedApproxBasket99,
 )
-from .average_basket import AverageBasket
+from .average_basket import AvgBasket
 
 __all__ = [
     "BaseFeature",
@@ -56,7 +56,7 @@ __all__ = [
     "MaxGrossSpend",
     "MinNetSpend",
     "MaxNetSpend",
-    "AverageGrossSpendPerBasket",
+    "AvgGrossSpendPerBasket",
     "Quantity",
     "AvgQuantityPerBasket",
     "MostRecentPurchaseDate",
@@ -75,5 +75,5 @@ __all__ = [
     "RecencyWeightedApproxBasket90",
     "RecencyWeightedApproxBasket95",
     "RecencyWeightedApproxBasket99",
-    "AverageBasket",
+    "AvgBasket",
 ]

--- a/jstark/features/average_basket.py
+++ b/jstark/features/average_basket.py
@@ -1,4 +1,4 @@
-"Average baskets per given periodunitofmeasure feature"
+"AvgBasket feature"
 
 from .feature import DerivedFeature
 
@@ -9,7 +9,7 @@ from jstark.feature_period import FeaturePeriod
 from .basket_count import BasketCount
 
 
-class AverageBasket(DerivedFeature):
+class AvgBasket(DerivedFeature):
     "Average baskets per given periodunitofmeasure feature"
 
     def column_expression(self) -> Column:

--- a/jstark/features/average_discount_per_basket.py
+++ b/jstark/features/average_discount_per_basket.py
@@ -1,4 +1,4 @@
-"""AverageDiscountPerBasket feature"""
+"""AvgDiscountPerBasket feature"""
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column

--- a/jstark/features/average_gross_spend_per_basket.py
+++ b/jstark/features/average_gross_spend_per_basket.py
@@ -1,4 +1,4 @@
-"""AverageGrossSpendPerBasket feature"""
+"""AvgGrossSpendPerBasket feature"""
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column
@@ -8,7 +8,7 @@ from .gross_spend import GrossSpend
 from .basket_count import BasketCount
 
 
-class AverageGrossSpendPerBasket(DerivedFeature):
+class AvgGrossSpendPerBasket(DerivedFeature):
     def column_expression(self) -> Column:
         return f.try_divide(
             GrossSpend(self.as_at, self.feature_period).column,

--- a/jstark/features/average_purchase_cycle.py
+++ b/jstark/features/average_purchase_cycle.py
@@ -1,4 +1,4 @@
-"""AveragePurchaseCycle feature"""
+"""AvgPurchaseCycle feature"""
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column

--- a/jstark/features/average_quantity_per_basket.py
+++ b/jstark/features/average_quantity_per_basket.py
@@ -1,4 +1,4 @@
-"""AverageQuantityPerBasket feature"""
+"""AvgQuantityPerBasket feature"""
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column

--- a/jstark/features/cycles_since_last_purchase.py
+++ b/jstark/features/cycles_since_last_purchase.py
@@ -4,19 +4,15 @@ import pyspark.sql.functions as f
 from pyspark.sql import Column
 
 from .feature import DerivedFeature
-from .earliest_purchase_date import EarliestPurchaseDate
-from .most_recent_purchase_date import MostRecentPurchaseDate
-from .basket_count import BasketCount
+from .average_purchase_cycle import AvgPurchaseCycle
+from .recency_days import RecencyDays
 
 
 class CyclesSinceLastPurchase(DerivedFeature):
     def column_expression(self) -> Column:
         return f.try_divide(
-            f.datediff(
-                MostRecentPurchaseDate(self.as_at, self.feature_period).column,
-                EarliestPurchaseDate(self.as_at, self.feature_period).column,
-            ),
-            BasketCount(self.as_at, self.feature_period).column,
+            RecencyDays(self.as_at, self.feature_period).column,
+            AvgPurchaseCycle(self.as_at, self.feature_period).column,
         )
 
     @property
@@ -27,7 +23,7 @@ class CyclesSinceLastPurchase(DerivedFeature):
     def commentary(self) -> str:
         return (
             "Days since last purchase divided by average purchase cycle. "
-            + "This may be a very good predictor of when a customer is "
+            + "This may be a predictor of when a customer is "
             + "likely to next buy a particular product."
         )
 

--- a/jstark/features/recency_days.py
+++ b/jstark/features/recency_days.py
@@ -1,16 +1,12 @@
 """RecencyDays feature"""
 
-from typing import Callable
 import pyspark.sql.functions as f
 from pyspark.sql import Column
 
-from .feature import BaseFeature
+from .min_feature import Min
 
 
-class RecencyDays(BaseFeature):
-    def aggregator(self) -> Callable[[Column], Column]:
-        return self.sum_aggregator
-
+class RecencyDays(Min):
     def column_expression(self) -> Column:
         return f.datediff(f.lit(self.as_at), f.col("Timestamp"))
 

--- a/jstark/grocery_retailer_feature_generator.py
+++ b/jstark/grocery_retailer_feature_generator.py
@@ -19,7 +19,7 @@ from jstark.features import (
     MaxGrossSpend,
     MinNetSpend,
     MaxNetSpend,
-    AverageGrossSpendPerBasket,
+    AvgGrossSpendPerBasket,
     Quantity,
     AvgQuantityPerBasket,
     MostRecentPurchaseDate,
@@ -38,7 +38,7 @@ from jstark.features import (
     RecencyWeightedApproxBasket90,
     RecencyWeightedApproxBasket95,
     RecencyWeightedApproxBasket99,
-    AverageBasket,
+    AvgBasket,
 )
 from jstark.feature_generator import FeatureGenerator
 
@@ -73,7 +73,7 @@ class GroceryRetailerFeatureGenerator(FeatureGenerator):
         MaxGrossSpend,
         MinNetSpend,
         MaxNetSpend,
-        AverageGrossSpendPerBasket,
+        AvgGrossSpendPerBasket,
         Quantity,
         AvgQuantityPerBasket,
         MostRecentPurchaseDate,
@@ -92,5 +92,5 @@ class GroceryRetailerFeatureGenerator(FeatureGenerator):
         RecencyWeightedApproxBasket95,
         RecencyWeightedApproxBasket90,
         RecencyWeightedApproxBasket99,
-        AverageBasket,
+        AvgBasket,
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,25 @@ def dataframe_of_faker_purchases(
 def dataframe_of_purchases(
     spark_session: SparkSession, as_at_timestamp: datetime, purchases_schema: StructType
 ) -> DataFrame:
+    # We need lots of transactions of the same thing just with different days so
+    # let's create the bulk of it once and then add the different days to it.
+    chew_car_timestamp = as_at_timestamp - timedelta(days=2)
+    chew_car = {
+        "Timestamp": chew_car_timestamp,
+        "Customer": "Chewie",
+        "Store": "Hammersmith",
+        "Channel": "Instore",
+        "Basket": uuid.uuid4(),
+        "items": [
+            {
+                "Product": "Carrot",
+                "Quantity": 1,
+                "GrossSpend": Decimal(0.1),
+                "NetSpend": Decimal(0.1),
+                "Discount": Decimal(0.0),
+            },
+        ],
+    }
     transactions = [
         {
             "Timestamp": as_at_timestamp - relativedelta(months=12),
@@ -154,6 +173,66 @@ def dataframe_of_purchases(
                     "Discount": Decimal(0.1),
                 },
             ],
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=3),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=5),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=6),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=9),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=10),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=12),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=13),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=15),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=16),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=17),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=18),
+        },
+        {
+            **chew_car,
+            "Basket": uuid.uuid4(),
+            "Timestamp": chew_car_timestamp - relativedelta(months=21),
         },
     ]
     flattened_transactions = FakeTransactions.flatten_transactions(transactions)

--- a/tests/test_grocery_retailer_feature_generator.py
+++ b/tests/test_grocery_retailer_feature_generator.py
@@ -310,10 +310,8 @@ def test_min_gross_spend_luke_and_leia_0y0(luke_and_leia_purchases_first: Row):
 def test_avg_gross_spend_per_basket_luke_and_leia_0y0(
     luke_and_leia_purchases_first: Row,
 ):
-    """Test AverageGrossSpendPerBasket_0y0"""
-    assert (
-        float(luke_and_leia_purchases_first["AverageGrossSpendPerBasket_0y0"]) == 5.15
-    )
+    """Test AvgGrossSpendPerBasket_0y0"""
+    assert float(luke_and_leia_purchases_first["AvgGrossSpendPerBasket_0y0"]) == 5.15
 
 
 def test_quantity_luke_and_leia_0y0(luke_and_leia_purchases_first: Row):
@@ -502,3 +500,39 @@ def test_averagebasketsperweek_luke_and_leia(
     total_baskets = sum(df_weeks_first[f"BasketCount_{i}w{i}"] for i in range(n))
     average_baskets_per_week = total_baskets / n
     assert average_baskets_per_week == df_first["AverageBasketsPerWeek_13w0"]
+
+
+def test_averagepurchasecycle_chewie_carrot(
+    dataframe_of_purchases: DataFrame,
+    purchasing_feature_generator: GroceryRetailerFeatureGenerator,
+):
+    """
+    Test AveragePurchaseCycle
+
+    The input df has lots of transactions of chewie buying a carrot on different days.
+    """
+    input_df = dataframe_of_purchases.where(f.col("Customer") == "Chewie").where(
+        f.col("Product") == "Carrot"
+    )
+    df = (
+        input_df.groupBy(["Customer", "Product"])
+        .agg(*purchasing_feature_generator.features)
+        .select(
+            [
+                "Customer",
+                "Product",
+                "AvgPurchaseCycle_2y0",
+                "CyclesSinceLastPurchase_2y0",
+                # The following are not required for the assertions but they all
+                # contribute to CyclesSinceLastPurchase so are useful for debugging.
+                "MostRecentPurchaseDate_2y0",
+                "EarliestPurchaseDate_2y0",
+                "BasketCount_2y0",
+                "RecencyDays_2y0",
+            ]
+        )
+    )
+    df_first = df.first()
+    assert df_first is not None
+    assert df_first["AvgPurchaseCycle_2y0"] == pytest.approx(45.5)
+    assert df_first["CyclesSinceLastPurchase_2y0"] == pytest.approx(2.065934065934066)


### PR DESCRIPTION
## Summary
- Redefine `CyclesSinceLastPurchase` as `RecencyDays / AvgPurchaseCycle` instead of `datediff(MostRecent, Earliest) / BasketCount`, giving a more meaningful measure of how overdue a customer's next purchase is
- Change `RecencyDays` to use `Min` aggregator (minimum days since as_at) instead of `Sum`
- Rename `AverageGrossSpendPerBasket` → `AvgGrossSpendPerBasket` and `AverageBasket` → `AvgBasket` for naming consistency
- Add Chewie/Carrot test data and assertions covering the new calculation

Closes #56
Closes #57

## Test plan
- [x] `uv run pytest` passes (all tests including new `test_averagepurchasecycle_chewie_carrot`)
- [x] `uv run pre-commit run --all-files` passes (ruff-format, ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)