### PR TITLE
Add proper type hints to FEATURE_CLASSES

### DIFF
--- a/jstark/feature_generator.py
+++ b/jstark/feature_generator.py
@@ -9,6 +9,7 @@ from pyspark.sql import Column, SparkSession
 
 from jstark.feature_period import FeaturePeriod, PeriodUnitOfMeasure
 from jstark.exceptions import FeaturePeriodMnemonicIsInvalid
+from jstark.features.feature import Feature
 
 
 class FeatureGenerator(metaclass=ABCMeta):
@@ -46,9 +47,7 @@ class FeatureGenerator(metaclass=ABCMeta):
                 )
         self.feature_periods = _feature_periods
 
-    # would prefer list[Type[Feature]] as type hint but
-    # this only works on py3.10 and above
-    FEATURE_CLASSES: list
+    FEATURE_CLASSES: list[type["Feature"]] = []
 
     @property
     def as_at(self) -> date:

--- a/jstark/grocery_retailer_feature_generator.py
+++ b/jstark/grocery_retailer_feature_generator.py
@@ -40,6 +40,7 @@ from jstark.features import (
     RecencyWeightedApproxBasket99,
     AvgBasket,
 )
+from jstark.features.feature import Feature
 from jstark.feature_generator import FeatureGenerator
 
 
@@ -54,9 +55,7 @@ class GroceryRetailerFeatureGenerator(FeatureGenerator):
     ) -> None:
         super().__init__(as_at, feature_periods)
 
-    # would prefer list[Type[Feature]] as type hint but
-    # this only works on py3.10 and above
-    FEATURE_CLASSES: list = [
+    FEATURE_CLASSES: list[type[Feature]] = [
         Count,
         NetSpend,
         GrossSpend,


### PR DESCRIPTION
## Summary
- Replace untyped `list` annotation with `list[type[Feature]]` on `FEATURE_CLASSES` in both `FeatureGenerator` and `GroceryRetailerFeatureGenerator`
- Remove outdated comments about Python 3.10 compatibility since 3.10 is now the minimum supported version
- Add default empty list to the base class declaration

## Test plan
- [x] Pre-commit hooks pass (mypy, ruff)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)