### PR TITLE
Add cog-generated grocery features table to README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,15 @@ name: build
 
 on:
   pull_request:
+    branches:
+    - main
   push:
     branches:
     - main
 
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ The `sample` extra installs [Faker](https://faker.readthedocs.io/), which is nee
 
 ```python
 from datetime import date
-from jstark.sample.transactions import FakeTransactions
+from jstark.sample.transactions import FakeGroceryTransactions
 from jstark.grocery import GroceryFeatures
 
-input_df = FakeTransactions().get_df(seed=42, number_of_baskets=10000)
+input_df = FakeGroceryTransactions().df
 gf = GroceryFeatures(date(2022, 1, 1), ["4q4", "3q3", "2q2", "1q1"])
 output_df = input_df.groupBy("Store").agg(*gf.features)
 output_df.select(
@@ -57,11 +57,11 @@ output_df.select(
 +-----------+---------------+---------------+---------------+---------------+
 |      Store|BasketCount_4q4|BasketCount_3q3|BasketCount_2q2|BasketCount_1q1|
 +-----------+---------------+---------------+---------------+---------------+
-|Hammersmith|            523|            529|            503|            492|
-|    Staines|            461|            520|            493|            504|
-|   Richmond|            500|            483|            503|            512|
-|     Ealing|            490|            460|            485|            515|
-| Twickenham|            484|            509|            514|            520|
+|    Staines|             47|             46|             48|             51|
+| Twickenham|             55|             57|             48|             49|
+|     Ealing|             52|             51|             50|             54|
+|Hammersmith|             47|             40|             43|             51|
+|   Richmond|             54|             40|             64|             53|
 +-----------+---------------+---------------+---------------+---------------+
 ```
 
@@ -89,6 +89,91 @@ gf.references["AvgGrossSpendPerBasket_1q1"]        # ['Basket', 'GrossSpend', 'T
 ```
 
 All features require a `Timestamp` column ([TimestampType](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.types.TimestampType.html)). Most require additional columns depending on what they measure.
+
+## Grocery features
+
+This is a list of all Grocery features for:
+
+```python
+GroceryFeatures(date(2022, 1, 1), ["3m1"])
+```
+
+<details>
+
+<!--[[[cog
+from datetime import date, datetime, time
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType, FloatType, IntegerType
+
+from jstark.feature_period import FeaturePeriod, PeriodUnitOfMeasure
+from jstark.grocery.grocery_features import GroceryFeatures
+
+d = date(2022, 1, 1)
+spark = SparkSession.builder.getOrCreate()
+schema = StructType(
+    [
+        StructField("Timestamp", TimestampType(), True),
+        StructField("Basket", StringType(), True),
+        StructField("Store", StringType(), True),
+        StructField("Customer", StringType(), True),
+        StructField("Channel", StringType(), True),
+        StructField("Product", StringType(), True),
+        StructField("Quantity", IntegerType(), True),
+        StructField("NetSpend", FloatType(), True),
+        StructField("GrossSpend", FloatType(), True),
+        StructField("Discount", FloatType(), True),
+    ]
+)
+df = spark.createDataFrame([(datetime.combine(d, time.min), "1234567890", "Store1", "Customer1", "Channel1", "Product1", 1, 1.2, 1.5, 0.3)], schema)
+period = FeaturePeriod(PeriodUnitOfMeasure.MONTH, 3, 1)
+gf = GroceryFeatures(d, [period])
+output_df = df.groupBy().agg(*gf.features)
+
+cog.outl("| Feature | Description |")
+cog.outl("| --- | --- |")
+for name, description in [(c.name, c.metadata["description"]) for c in output_df.schema]:
+    cog.outl(f"| {name} | {description} |")
+]]]-->
+| Feature | Description |
+| --- | --- |
+| Count_3m1 | Count of rows between 2021-10-01 and 2021-12-31 |
+| NetSpend_3m1 | Sum of NetSpend between 2021-10-01 and 2021-12-31 |
+| GrossSpend_3m1 | Sum of GrossSpend between 2021-10-01 and 2021-12-31 |
+| RecencyDays_3m1 | Minimum number of days since occurrence between 2021-10-01 and 2021-12-31 |
+| BasketCount_3m1 | Distinct count of Baskets between 2021-10-01 and 2021-12-31 |
+| StoreCount_3m1 | Distinct count of Stores between 2021-10-01 and 2021-12-31 |
+| ProductCount_3m1 | Distinct count of Products between 2021-10-01 and 2021-12-31 |
+| CustomerCount_3m1 | Distinct count of Customers between 2021-10-01 and 2021-12-31 |
+| ChannelCount_3m1 | Distinct count of Channels between 2021-10-01 and 2021-12-31 |
+| ApproxBasketCount_3m1 | Approximate distinct count of Baskets between 2021-10-01 and 2021-12-31 |
+| ApproxCustomerCount_3m1 | Approximate distinct count of Customers between 2021-10-01 and 2021-12-31 |
+| Discount_3m1 | Sum of Discount between 2021-10-01 and 2021-12-31 |
+| MinGrossSpend_3m1 | Minimum GrossSpend value between 2021-10-01 and 2021-12-31 |
+| MaxGrossSpend_3m1 | Maximum GrossSpend value between 2021-10-01 and 2021-12-31 |
+| MinNetSpend_3m1 | Minimum of NetSpend value between 2021-10-01 and 2021-12-31 |
+| MaxNetSpend_3m1 | Maximum of NetSpend value between 2021-10-01 and 2021-12-31 |
+| AvgGrossSpendPerBasket_3m1 | Average GrossSpend per Basket between 2021-10-01 and 2021-12-31 |
+| Quantity_3m1 | Sum of Quantity between 2021-10-01 and 2021-12-31 |
+| AvgQuantityPerBasket_3m1 | Average Quantity per Basket between 2021-10-01 and 2021-12-31 |
+| MostRecentPurchaseDate_3m1 | Most recent purchase date between 2021-10-01 and 2021-12-31 |
+| MinNetPrice_3m1 | Minimum of (NetSpend / Quantity) between 2021-10-01 and 2021-12-31 |
+| MaxNetPrice_3m1 | Maximum of (NetSpend / Quantity) between 2021-10-01 and 2021-12-31 |
+| MinGrossPrice_3m1 | Minimum of (GrossSpend / Quantity) between 2021-10-01 and 2021-12-31 |
+| MaxGrossPrice_3m1 | Maximum of (GrossSpend / Quantity) between 2021-10-01 and 2021-12-31 |
+| EarliestPurchaseDate_3m1 | Earliest purchase date between 2021-10-01 and 2021-12-31 |
+| AvgDiscountPerBasket_3m1 | Average Discount per Basket between 2021-10-01 and 2021-12-31 |
+| AvgPurchaseCycle_3m1 | Average purchase cycle between 2021-10-01 and 2021-12-31 |
+| CyclesSinceLastPurchase_3m1 | Cycles since last purchase between 2021-10-01 and 2021-12-31 |
+| BasketMonths_3m1 | Number of months in which at least one basket was purchased between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedBasketMonths95_3m1 | Exponentially weighted moving average, with smoothing factor of 0.95, of the number of baskets per month between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedBasketMonths90_3m1 | Exponentially weighted moving average, with smoothing factor of 0.9, of the number of baskets per month between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedBasketMonths99_3m1 | Exponentially weighted moving average, with smoothing factor of 0.99, of the number of baskets per month between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedApproxBasketMonths95_3m1 | Exponentially weighted moving average, with smoothing factor of 0.95, of the approximate number of baskets per month between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedApproxBasketMonths90_3m1 | Exponentially weighted moving average, with smoothing factor of 0.9, of the approximate number of baskets per month between 2021-10-01 and 2021-12-31 |
+| RecencyWeightedApproxBasketMonths99_3m1 | Exponentially weighted moving average, with smoothing factor of 0.99, of the approximate number of baskets per month between 2021-10-01 and 2021-12-31 |
+| AverageBasketsPerMonth_3m1 | Average number of baskets per month between 2021-10-01 and 2021-12-31 |
+<!--[[[end]]]-->
+</details>
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add a "Grocery features" section to README with a markdown table listing all 36 features and their descriptions
- Table is auto-generated using cogapp from `GroceryFeatures.FEATURE_CLASSES`, keeping docs in sync with code
- Regenerate with `uv run cog -r README.md`

## Test plan
- [ ] Verify the rendered table displays correctly on GitHub
- [ ] Confirm `uv run cog -r README.md` is idempotent (re-running produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)