### PR TITLE
Rename FakeTransactions to FakeGroceryTransactions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pyspark.sql.functions as f
 from pyspark.sql.types import StructType
 from jstark.grocery import GroceryFeatures
 from jstark.feature_period import FeaturePeriod, PeriodUnitOfMeasure
-from jstark.sample.transactions import FakeTransactions
+from jstark.sample.transactions import FakeGroceryTransactions
 
 
 @pytest.fixture(scope="session")
@@ -37,14 +37,12 @@ def as_at_timestamp() -> datetime:
 
 @pytest.fixture(scope="session")
 def purchases_schema() -> StructType:
-    return FakeTransactions().transactions_schema
+    return FakeGroceryTransactions().transactions_schema
 
 
 @pytest.fixture(scope="session")
-def dataframe_of_faker_purchases(
-    spark_session: SparkSession, as_at_timestamp: datetime, purchases_schema: StructType
-) -> DataFrame:
-    return FakeTransactions().get_df(seed=42, number_of_baskets=10000)
+def dataframe_of_faker_purchases() -> DataFrame:
+    return FakeGroceryTransactions(seed=42, number_of_baskets=10000).df
 
 
 @pytest.fixture(scope="session")
@@ -235,7 +233,7 @@ def dataframe_of_purchases(
             "Timestamp": chew_car_timestamp - relativedelta(months=21),
         },
     ]
-    flattened_transactions = FakeTransactions.flatten_transactions(transactions)
+    flattened_transactions = FakeGroceryTransactions.flatten_transactions(transactions)
     return spark_session.createDataFrame(
         flattened_transactions,
         schema=purchases_schema,  # type: ignore

--- a/tests/test_fake_transactions.py
+++ b/tests/test_fake_transactions.py
@@ -2,27 +2,26 @@
 
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as f
-from jstark.sample.transactions import FakeTransactions
+from jstark.sample.transactions import FakeGroceryTransactions
 
 
 def test_fake_transactions_returns_a_dataframe():
     """In order to get 100% code coverage we need to call
-    FakeTransactions().get_df() without a seed
+    FakeGroceryTransactions().get_df() without a seed
     """
-    assert isinstance(FakeTransactions().get_df(), DataFrame)
+    assert isinstance(FakeGroceryTransactions().df, DataFrame)
 
 
 def test_number_of_baskets_is_correct():
     """
-    Had a bug where FakeTransactions was returning the wrong number of baskets.
+    Had a bug where FakeGroceryTransactions was returning the wrong number of baskets.
     First wrote this test to verify the correct behaviour and then made the test pass.
     Might as well leave the test here.
     """
     number_of_baskets = 1234
     first = (
-        FakeTransactions()
-        .get_df(number_of_baskets=number_of_baskets)
-        .groupBy()
+        FakeGroceryTransactions(number_of_baskets=number_of_baskets)
+        .df.groupBy()
         .agg(f.countDistinct("Basket").alias("baskets"))
         .first()
     )


### PR DESCRIPTION
## Summary
- Rename `FakeTransactions` to `FakeGroceryTransactions` for consistency with the grocery-domain naming convention
- Move `seed` and `number_of_baskets` from `get_df()` parameters to constructor arguments
- Replace `get_df()` method with a `cached_property` `df`
- Update all usages in `conftest.py` and `test_fake_transactions.py`

## Test plan
- [ ] CI passes across all Python/PySpark/OS combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)