### PR TITLE
Bump CI actions and improve uv caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,15 +63,22 @@ jobs:
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: 0.10.6   # bump this regularly
+        enable-cache: true
+        cache-dependency-glob: uv.lock
+
     - name: Install dependencies
-      run: uv sync --extra faker
+      run: uv sync --extra faker --locked
 
     - name: Install PySpark ${{ matrix.pyspark-version }}
       run: uv pip install 'pyspark==${{ matrix.pyspark-version }}.*'
@@ -93,6 +100,10 @@ jobs:
       with:
         name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}-pyspark${{ matrix.pyspark-version }}
         path: _site
+
+    # minimize is recommended at https://docs.astral.sh/uv/guides/integration/github/#caching
+    - name: Minimize uv cache
+      run: uv cache prune --ci
 
   upload-pages-artifacts:
     needs: [run, pylint, lint]

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,9 +10,11 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
+      with:
+        python-version-file: .python-version
 
     - name: pre-commit install autoupdate
       run: |


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` to v6, `actions/setup-python` to v6, `astral-sh/setup-uv` to v7
- Add explicit `setup-python` step in the test matrix job
- Enable uv caching keyed on `uv.lock` and pin uv version to `0.10.6`
- Add `--locked` to `uv sync` to fail fast if lockfile is stale
- Add `uv cache prune --ci` step per [uv CI caching guide](https://docs.astral.sh/uv/guides/integration/github/#caching)
- Use `python-version-file: .python-version` in `pre-commit-update.yml`

## Test plan
- [ ] CI passes across all Python/PySpark/OS combinations
- [ ] Verify uv cache is restored on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)