### PR TITLE
Bump peter-evans/create-pull-request from v3 to v7

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -21,7 +21,7 @@ jobs:
         pip install pre-commit
         pre-commit autoupdate
 
-    - uses: peter-evans/create-pull-request@v3
+    - uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: chore/update-pre-commit-hooks


### PR DESCRIPTION
## Summary
- Upgrades `peter-evans/create-pull-request` from v3 to v7 in the pre-commit auto-update workflow
- Fixes "Duplicate header: Authorization" error caused by incompatibility between the old v3 action and `actions/checkout@v6` ([failing run](https://github.com/jamiekt/jstark/actions/runs/22425998104/job/64966530881))

## Test plan
- [ ] Re-run the pre-commit auto-update workflow and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)