### PR TITLE
Add PyPI publish workflow triggered by semver tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: publish
+
+on:
+  push:
+    tags:
+    - v*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Install dependencies
+      run: uv sync --extra faker
+
+    - name: Run tests
+      run: uv run pytest -vvv
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0  # needed for hatch-vcs to determine version from tags
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Build
+      run: uv build
+
+    - name: Publish to PyPI
+      run: uv publish --trusted-publishing always

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dmypy.json
 
 .vscode
 
+# hatch-vcs generated version file
+jstark/_version.py
+
 pylint.html
 pylint.out
 pylint.svg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,24 @@ uv creates a standard `.venv/` directory in the project root. VS Code should det
 *Contributions welcomed here*
 
 
+## Releasing
+
+jstark follows [semver](https://semver.org/). The package version is derived automatically from git tags using [hatch-vcs](https://github.com/ofek/hatch-vcs) — there is no hardcoded version in the source code.
+
+To publish a new release:
+
+1. Ensure all changes are merged to `main` and CI is green.
+1. Create and push a tag:
+
+   ```shell
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+1. The `publish.yml` workflow will run tests, build the package, and publish to PyPI using trusted publishing.
+
+Tag names **must** start with `v` followed by a semver version (e.g. `v0.1.0`, `v1.0.0`, `v2.3.1`).
+
 ## Troubleshooting
 
 ### libffi-dev on wsl

--- a/jstark/__about__.py
+++ b/jstark/__about__.py
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2022-present Jamie Thomson
-#
-# SPDX-License-Identifier: MIT
-"""__about__.py"""
-
-__version__ = "0.0.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -38,7 +38,10 @@ Issues = "https://github.com/unknown/jstark/issues"
 Source = "https://github.com/unknown/jstark"
 
 [tool.hatch.version]
-path = "jstark/__about__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "jstark/_version.py"
 
 [dependency-groups]
 dev = [
@@ -63,7 +66,7 @@ select = ["E", "F", "W"]
 branch = true
 parallel = true
 omit = [
-  "jstark/__about__.py",
+  "jstark/_version.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

- Switch version management from hardcoded `jstark/__about__.py` to `hatch-vcs`, which derives the version from git tags at build time
- Add `.github/workflows/publish.yml` that builds and publishes to PyPI using trusted publishing (OIDC) when a `v*` tag is pushed
- Add releasing instructions to `CONTRIBUTING.md`

## Test plan

- [x] All 82 tests pass locally after removing `__about__.py`
- [x] `uv sync` correctly derives version from git history via hatch-vcs
- [ ] After merge, create a tag (`git tag v0.1.0 && git push origin v0.1.0`) and verify the publish workflow runs and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)