### PR TITLE
Pin pyspark dependency to >=3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pyspark",
+  "pyspark>=3.5",
   "python-dateutil",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faker", marker = "extra == 'faker'", specifier = ">=40.0.0" },
-    { name = "pyspark" },
+    { name = "pyspark", specifier = ">=3.5" },
     { name = "python-dateutil" },
 ]
 provides-extras = ["faker"]


### PR DESCRIPTION
## Summary

- Constrain `pyspark` dependency from unconstrained to `>=3.5`, matching the test matrix minimum

## Test plan

- [ ] CI passes with the constrained dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)