### PR TITLE
Fix TypeError when as_at is a datetime

### DIFF
--- a/jstark/features/feature.py
+++ b/jstark/features/feature.py
@@ -95,11 +95,15 @@ class Feature(metaclass=ABCMeta):
 
     @property
     def end_date(self) -> date:
-        n_days_ago = self.as_at - timedelta(days=self.feature_period.end)
-        n_weeks_ago = self.as_at - timedelta(weeks=self.feature_period.end)
-        n_months_ago = self.as_at - relativedelta(months=self.feature_period.end)
-        n_quarters_ago = self.as_at - relativedelta(months=self.feature_period.end * 3)
-        n_years_ago = self.as_at - relativedelta(years=self.feature_period.end)
+        # Convert datetime to date if needed
+        as_at_date = (
+            self.as_at.date() if isinstance(self.as_at, datetime) else self.as_at
+        )
+        n_days_ago = as_at_date - timedelta(days=self.feature_period.end)
+        n_weeks_ago = as_at_date - timedelta(weeks=self.feature_period.end)
+        n_months_ago = as_at_date - relativedelta(months=self.feature_period.end)
+        n_quarters_ago = as_at_date - relativedelta(months=self.feature_period.end * 3)
+        n_years_ago = as_at_date - relativedelta(years=self.feature_period.end)
         match self.feature_period.period_unit_of_measure:
             case PeriodUnitOfMeasure.DAY:
                 last_day_of_period = n_days_ago
@@ -120,7 +124,7 @@ class Feature(metaclass=ABCMeta):
                     n_years_ago
                 ).last_date_in_year
         # min() is used to ensure we don't return a date later than self.as_at
-        return min(last_day_of_period, self.as_at)
+        return min(last_day_of_period, as_at_date)
 
     @property
     def column_metadata(self) -> dict[str, str]:

--- a/tests/test_mealkit_features.py
+++ b/tests/test_mealkit_features.py
@@ -12,10 +12,10 @@ def test_orderweeks(
     OrderWeeks is the number of weeks in which at least one order was placed
 
     """
-    pfg = MealkitFeatures(as_at=as_at_timestamp, feature_periods=["52w0"])
+    mf = MealkitFeatures(as_at=as_at_timestamp, feature_periods=["52w0"])
     output_df = (
         dataframe_of_faker_mealkit_orders.groupBy()
-        .agg(*pfg.features)
+        .agg(*mf.features)
         .select("OrderCount_52w0")
     )
     first = output_df.first()
@@ -23,21 +23,16 @@ def test_orderweeks(
     assert first["OrderCount_52w0"] == 872
 
 
-# def test_basketweeks_commentary(
-#     as_at_timestamp: datetime, dataframe_of_faker_purchases: DataFrame
-# ):
-#     """Test BasketWeeks commentary"""
-#     pfg = MealkitFeatures(as_at=as_at_timestamp, feature_periods=["52w1"])
-#     output_df = (
-#         dataframe_of_faker_purchases.groupBy()
-#         .agg(*pfg.features)
-#         .select("BasketWeeks_52w1")
-#     )
-#     assert [(c.metadata["commentary"]) for c in output_df.schema][0] == (
-#         "The number of weeks in which at least one basket was purchased. "
-#         + "The value will be in the range 0 to 52"
-#         + " because 52 is the number of weeks between 2021-11-28 and 2022-11-26."
-#         + " When grouped by Customer and Product"
-#         + " this feature is a useful indicator of the frequency of which a"
-#         + " Customer purchases a Product."
-#     )
+def test_as_at_timestamp(dataframe_of_faker_mealkit_orders: DataFrame):
+    """
+    We had a situaiton where as_at was being passed as a datetime (which we support)
+    however an error was still occurring:
+    > TypeError: can't compare datetime.datetime to datetime.date
+    Following TDD this was written as a failing test which was then fixed,
+    the fix is in the same commit as this test.
+    """
+    as_at_timestamp = datetime(2022, 11, 30, 10, 12, 13)
+    mf = MealkitFeatures(
+        as_at=as_at_timestamp, feature_periods=["1q1", "2q2", "3q3", "4q4"]
+    )
+    dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)


### PR DESCRIPTION
## Summary
- Fix `TypeError: can't compare datetime.datetime to datetime.date` in `Feature.end_date` when `as_at` is passed as a `datetime` instead of `date`
- Convert `as_at` to `date` before performing date arithmetic and comparisons
- Add regression test for this scenario

Closes #94

## Test plan
- [x] New test `test_as_at_timestamp` verifies no error when `as_at` is a `datetime`
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)