### PR TITLE
Allow caller to specify which features they want

### DIFF
--- a/jstark/feature_generator.py
+++ b/jstark/feature_generator.py
@@ -17,10 +17,15 @@ class FeatureGenerator(metaclass=ABCMeta):
     def __init__(
         self,
         as_at: date,
-        feature_periods: list[FeaturePeriod] | list[str] = [
-            FeaturePeriod(PeriodUnitOfMeasure.WEEK, 52, 0),
-        ],
+        feature_periods: list[FeaturePeriod] | list[str] | None = None,
+        feature_stems: set[str] | list[str] | None = None,
     ) -> None:
+        if feature_periods is None:
+            feature_periods = [FeaturePeriod(PeriodUnitOfMeasure.WEEK, 52, 0)]
+        if feature_stems is None:
+            feature_stems = set[str]()
+        if isinstance(feature_stems, list):
+            feature_stems = set[str](feature_stems)
         self.as_at = as_at
         period_unit_of_measure_values = "".join([e.value for e in PeriodUnitOfMeasure])
         regex = (
@@ -43,8 +48,9 @@ class FeatureGenerator(metaclass=ABCMeta):
                     )
                 )
         self.feature_periods = _feature_periods
+        self.feature_stems = feature_stems
 
-    FEATURE_CLASSES: list[type["Feature"]] = []
+    FEATURE_CLASSES: set[type["Feature"]] = set[type["Feature"]]()
 
     @property
     def as_at(self) -> date:
@@ -64,14 +70,25 @@ class FeatureGenerator(metaclass=ABCMeta):
 
     @property
     def features(self) -> list[Column]:
+        # Find feature stems that do not correspond to any class in FEATURE_CLASSES.
+        # If any are not found, raise an Exception.
+        missing_stems = self.feature_stems - {
+            cls.__name__ for cls in self.FEATURE_CLASSES
+        }
+        if missing_stems:
+            # Only raise on the first (sorted for determinism)
+            raise Exception(f"Feature(s) {sorted(missing_stems)} not found")
+        desired_features = (
+            [fc for fc in self.FEATURE_CLASSES if fc.__name__ in self.feature_stems]
+            if self.feature_stems
+            else self.FEATURE_CLASSES
+        )
         return [
             feature.column
             for feature in [
                 f[0](as_at=self.as_at, feature_period=f[1])
                 for f in (
-                    (cls, fp)
-                    for cls in self.FEATURE_CLASSES
-                    for fp in self.feature_periods
+                    (cls, fp) for cls in desired_features for fp in self.feature_periods
                 )
             ]
         ]

--- a/jstark/grocery/grocery_features.py
+++ b/jstark/grocery/grocery_features.py
@@ -52,10 +52,11 @@ class GroceryFeatures(FeatureGenerator):
             FeaturePeriod(PeriodUnitOfMeasure.DAY, 2, 0),
             FeaturePeriod(PeriodUnitOfMeasure.DAY, 4, 3),
         ],
+        feature_stems: set[str] | list[str] = set[str](),
     ) -> None:
-        super().__init__(as_at, feature_periods)
+        super().__init__(as_at, feature_periods, feature_stems)
 
-    FEATURE_CLASSES: list[type[Feature]] = [
+    FEATURE_CLASSES: set[type[Feature]] = {
         Count,
         NetSpend,
         GrossSpend,
@@ -93,4 +94,4 @@ class GroceryFeatures(FeatureGenerator):
         RecencyWeightedApproxBasket90,
         RecencyWeightedApproxBasket99,
         AvgBasket,
-    ]
+    }

--- a/jstark/mealkit/mealkit_features.py
+++ b/jstark/mealkit/mealkit_features.py
@@ -32,10 +32,11 @@ class MealkitFeatures(FeatureGenerator):
             FeaturePeriod(PeriodUnitOfMeasure.DAY, 2, 0),
             FeaturePeriod(PeriodUnitOfMeasure.DAY, 4, 3),
         ],
+        feature_stems: set[str] | list[str] = set[str](),
     ) -> None:
-        super().__init__(as_at, feature_periods)
+        super().__init__(as_at, feature_periods, feature_stems)
 
-    FEATURE_CLASSES: list[type[Feature]] = [
+    FEATURE_CLASSES: set[type[Feature]] = {
         Count,
         # NetSpend,
         # GrossSpend,
@@ -57,4 +58,4 @@ class MealkitFeatures(FeatureGenerator):
         AvgQuantityPerOrder,
         CyclesSinceLastOrder,
         AvgPurchaseCycle,
-    ]
+    }

--- a/tests/test_mealkit_features.py
+++ b/tests/test_mealkit_features.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, date
+import pytest
 from pyspark.sql import DataFrame
 
 from jstark.mealkit.mealkit_features import MealkitFeatures
@@ -36,3 +37,32 @@ def test_as_at_timestamp(dataframe_of_faker_mealkit_orders: DataFrame):
         as_at=as_at_timestamp, feature_periods=["1q1", "2q2", "3q3", "4q4"]
     )
     dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)
+
+
+def test_desired_features(dataframe_of_faker_mealkit_orders: DataFrame):
+    mf = MealkitFeatures(
+        as_at=date(2022, 11, 30),
+        feature_periods=["1q1", "2q2", "3q3", "4q4"],
+        feature_stems=["OrderCount"],
+    )
+    output_df = dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)
+    assert output_df.columns == [
+        "OrderCount_1q1",
+        "OrderCount_2q2",
+        "OrderCount_3q3",
+        "OrderCount_4q4",
+    ]
+
+
+def test_non_existent_desired_features(dataframe_of_faker_mealkit_orders: DataFrame):
+    mf = MealkitFeatures(
+        as_at=date(2022, 11, 30),
+        feature_periods=["1q1", "2q2", "3q3", "4q4"],
+        feature_stems=["NonExistentFeature", "NonExistentFeature2"],
+    )
+    with pytest.raises(Exception) as exc_info:
+        dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)
+    assert (
+        str(exc_info.value)
+        == "Feature(s) ['NonExistentFeature', 'NonExistentFeature2'] not found"
+    )


### PR DESCRIPTION
## Summary
- Adds a `feature_stems` parameter to `FeatureGenerator` and its subclasses (`GroceryFeatures`, `MealkitFeatures`) so callers can select a subset of features by name
- Raises an exception when unrecognized feature stems are provided
- Converts `FEATURE_CLASSES` from `list` to `set`

## Test plan
- [x] Added test for selecting desired features via `feature_stems`
- [x] Added test for non-existent feature stems raising an exception
- [x] Pre-commit hooks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)