### PR TITLE
Make feature_periods accept and default to a set

### DIFF
--- a/jstark/feature_generator.py
+++ b/jstark/feature_generator.py
@@ -17,11 +17,15 @@ class FeatureGenerator(metaclass=ABCMeta):
     def __init__(
         self,
         as_at: date,
-        feature_periods: list[FeaturePeriod] | list[str] | None = None,
+        feature_periods: list[FeaturePeriod]
+        | list[str]
+        | set[FeaturePeriod]
+        | set[str]
+        | None = None,
         feature_stems: set[str] | list[str] | None = None,
     ) -> None:
         if feature_periods is None:
-            feature_periods = [FeaturePeriod(PeriodUnitOfMeasure.WEEK, 52, 0)]
+            feature_periods = {FeaturePeriod(PeriodUnitOfMeasure.WEEK, 52, 0)}
         if feature_stems is None:
             feature_stems = set[str]()
         if isinstance(feature_stems, list):


### PR DESCRIPTION
## Summary
- `feature_periods` parameter now accepts `set[FeaturePeriod]` and `set[str]` in addition to lists
- Default value changed from a list to a set, since order doesn't matter and duplicates should be ignored

Closes #98

## Test plan
- [ ] Verify existing tests pass with the updated type signature
- [ ] Confirm callers can pass sets for `feature_periods`

🤖 Generated with [Claude Code](https://claude.com/claude-code)