### PR TITLE
feat: Add per-cuisine CountIf features

### DIFF
--- a/jstark/features/count_if.py
+++ b/jstark/features/count_if.py
@@ -1,0 +1,23 @@
+"""CountIf feature"""
+
+from typing import Callable
+import pyspark.sql.functions as f
+from pyspark.sql import Column
+
+
+from jstark.features.feature import BaseFeature
+
+
+class CountIf(BaseFeature):
+    def aggregator(self) -> Callable[[Column], Column]:
+        return self.count_if_aggregator
+
+    def column_expression(self) -> Column:
+        return f.lit(1)
+
+    def default_value(self) -> Column:
+        return f.lit(0)
+
+    @property
+    def description_subject(self) -> str:
+        return "Count of rows if condition is met"

--- a/jstark/features/feature.py
+++ b/jstark/features/feature.py
@@ -171,6 +171,9 @@ class BaseFeature(Feature, metaclass=ABCMeta):
     def count_aggregator(self, column: Column) -> Column:
         return f.count(column)
 
+    def count_if_aggregator(self, column: Column) -> Column:
+        return f.count_if(column)
+
     def count_distinct_aggregator(self, column: Column) -> Column:
         return f.countDistinct(column)
 

--- a/jstark/mealkit/cuisine_count.py
+++ b/jstark/mealkit/cuisine_count.py
@@ -4,6 +4,7 @@ import pyspark.sql.functions as f
 from pyspark.sql import Column
 
 from jstark.features.distinctcount_feature import DistinctCount
+from jstark.features.count_if import CountIf
 
 
 class CuisineCount(DistinctCount):
@@ -22,3 +23,396 @@ class CuisineCount(DistinctCount):
             + "this feature allows you to determine how many distinct cuisines "
             + "have been ordered."
         )
+
+
+class CuisineCountIf(CountIf):
+    CUISINE_NAME: str = ""
+
+    def column_expression(self) -> Column:
+        # Compare lowercase cuisine to class's CUISINE_NAME (also lowercase)
+        return f.lower(f.col("Cuisine")) == self.CUISINE_NAME.lower()
+
+    @property
+    def description_subject(self) -> str:
+        return f"Count of {self.CUISINE_NAME.capitalize()} recipes"
+
+    @property
+    def commentary(self) -> str:
+        name = self.CUISINE_NAME.capitalize()
+        return (
+            f"The number of {name} recipes. Typically the "
+            + "dataframe supplied to this feature will have "
+            + "many recipes for the same cuisine, this feature "
+            + f"allows you to determine how many {name} "
+            + "recipes have been ordered."
+        )
+
+
+# This list of classes was based upon all the observed cuisines in
+# all recipes from a well-known mealkit provider in 2025
+class ItalianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "italian"
+
+
+class FrenchCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "french"
+
+
+class SpanishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "spanish"
+
+
+class SrilankanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "srilankan"
+
+
+class LebaneseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "lebanese"
+
+
+class GreekCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "greek"
+
+
+class VietnameseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "vietnamese"
+
+
+class DanishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "danish"
+
+
+class WesternEuropeCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "westerneurope"
+
+
+class FusionCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "fusion"
+
+
+class DutchCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "dutch"
+
+
+class KoreanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "korean"
+
+
+class SouthEastAsianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "southeast-asian"
+
+
+class MalaysianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "malay"
+
+
+class AmericanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "american"
+
+
+class AsianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "asian"
+
+
+class IndianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "indian"
+
+
+class GermanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "german"
+
+
+class CentralAmericaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "central america"
+
+
+class ArgentinianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "argentinian"
+
+
+class NorthAmericanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "north american"
+
+
+class NewZealandCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "new zealand"
+
+
+class CanadianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "canadian"
+
+
+class SwedishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "swedish"
+
+
+class EgyptianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "egyptian"
+
+
+class NorthernEuropeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "northern europe"
+
+
+class CajunCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "cajun"
+
+
+class AustrianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "austrian"
+
+
+class MexicanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "mexican"
+
+
+class MediterraneanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "mediterranean"
+
+
+class ThaiCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "thai"
+
+
+class ChineseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "chinese"
+
+
+class LatinAmericanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "latin american"
+
+
+class SouthAsiaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "south asia"
+
+
+class MiddleEasternCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "middleeastern"
+
+
+class TraditionalCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "traditional"
+
+
+class SteakhouseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "steakhouse"
+
+
+class PacificislandsCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "pacificislands"
+
+
+class EastAsiaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "east asia"
+
+
+class BritishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "british"
+
+
+class CaribbeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "caribbean"
+
+
+class FilipinoCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "filipino"
+
+
+class TurkishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "turkish"
+
+
+class BelgianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "belgian"
+
+
+class SouthAmericanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "south american"
+
+
+class NorthAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "north african"
+
+
+class SouthAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "south african"
+
+
+class WestAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "west african"
+
+
+class EastAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "east african"
+
+
+class WesternEuropeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "western-european"
+
+
+class PortugueseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "portuguese"
+
+
+class PeruvianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "peruvian"
+
+
+class JapaneseCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "japanese"
+
+
+class PacificIslandsCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "pacific-islands"
+
+
+class SouthernEuropeCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "southern europe"
+
+
+class AfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "african"
+
+
+class CentralAsiaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "centralasia"
+
+
+class NorthamericaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "northamerica"
+
+
+class EuropeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "european"
+
+
+class MoroccanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "moroccan"
+
+
+class AustralianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "australian"
+
+
+class HungarianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "hungarian"
+
+
+class IranianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "iranian"
+
+
+class SoutheastAsiaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "southeast asia"
+
+
+class HawaiianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "hawaiian"
+
+
+class ScandinavianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "scandinavian"
+
+
+class BrazilianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "brazilian"
+
+
+class IndonesianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "indonesian"
+
+
+class MongolianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "mongolian"
+
+
+class RussianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "russian"
+
+
+class SouthAsianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "south-asian"
+
+
+class BulgarianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "bulgarian"
+
+
+class FusionCuisineCusiineCount(CuisineCountIf):
+    CUISINE_NAME = "fusion-cuisine"
+
+
+class IrishCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "irish"
+
+
+class GeorgianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "georgian"
+
+
+class SouthwestCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "southwest"
+
+
+class CambodianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "cambodian"
+
+
+class LatinCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "latin"
+
+
+class CubanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "cuban"
+
+
+class SoutheastCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "southeast"
+
+
+class SouthHyphenAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "south-african"
+
+
+class JamaicanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "jamaican"
+
+
+class IsrealiCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "israeli"
+
+
+class EasteuropeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "easteuropean"
+
+
+class SingaporeanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "singaporean"
+
+
+class NordicCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "nordic"
+
+
+class WestHyphenAfricanCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "west-african"
+
+
+class NortheastCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "northeast"
+
+
+class TonganCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "tongan"
+
+
+class WestafricaCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "westafrica"
+
+
+class ZanzibarianCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "zanzibarian"
+
+
+class MidwestCuisineCount(CuisineCountIf):
+    CUISINE_NAME = "midwest"

--- a/jstark/mealkit/mealkit_features.py
+++ b/jstark/mealkit/mealkit_features.py
@@ -24,6 +24,127 @@ from jstark.mealkit.cycles_since_last_order import CyclesSinceLastOrder
 from jstark.mealkit.average_purchase_cycle import AvgPurchaseCycle
 from jstark.mealkit.cuisines import Cuisines
 from jstark.mealkit.cuisine_count import CuisineCount
+from jstark.mealkit.cuisine_count import (
+    ItalianCuisineCount,
+    FrenchCuisineCount,
+    SpanishCuisineCount,
+    SrilankanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    MalaysianCuisineCount,
+    AmericanCuisineCount,
+    AsianCuisineCount,
+    GermanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    CentralAmericaCuisineCount,
+    ArgentinianCuisineCount,
+    NorthAmericanCuisineCount,
+    NewZealandCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    CanadianCuisineCount,
+    SwedishCuisineCount,
+    EgyptianCuisineCount,
+    NorthernEuropeanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    CajunCuisineCount,
+    AustrianCuisineCount,
+    MexicanCuisineCount,
+    MediterraneanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    ThaiCuisineCount,
+    ChineseCuisineCount,
+    LatinAmericanCuisineCount,
+    SouthAsiaCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    MiddleEasternCuisineCount,
+    TraditionalCuisineCount,
+    SteakhouseCuisineCount,
+    PacificislandsCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    EastAsiaCuisineCount,
+    BritishCuisineCount,
+    CaribbeanCuisineCount,
+    FilipinoCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    TurkishCuisineCount,
+    BelgianCuisineCount,
+    SouthAmericanCuisineCount,
+    NorthAfricanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    SouthAfricanCuisineCount,
+    WestAfricanCuisineCount,
+    EastAfricanCuisineCount,
+    WesternEuropeanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    PortugueseCuisineCount,
+    PeruvianCuisineCount,
+    JapaneseCuisineCount,
+    PacificIslandsCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    SouthernEuropeCuisineCount,
+    AfricanCuisineCount,
+    CentralAsiaCuisineCount,
+    NorthamericaCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    EuropeanCuisineCount,
+    MoroccanCuisineCount,
+    AustralianCuisineCount,
+    HungarianCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    IranianCuisineCount,
+    SoutheastAsiaCuisineCount,
+    HawaiianCuisineCount,
+    ScandinavianCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    BrazilianCuisineCount,
+    IndonesianCuisineCount,
+    MongolianCuisineCount,
+    RussianCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    SouthAsianCuisineCount,
+    BulgarianCuisineCount,
+    FusionCuisineCusiineCount,
+    IrishCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    GeorgianCuisineCount,
+    SouthwestCuisineCount,
+    CambodianCuisineCount,
+    LatinCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    CubanCuisineCount,
+    SoutheastCuisineCount,
+    SouthHyphenAfricanCuisineCount,
+    JamaicanCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    IsrealiCuisineCount,
+    EasteuropeanCuisineCount,
+    SingaporeanCuisineCount,
+    NordicCuisineCount,
+)
+from jstark.mealkit.cuisine_count import (
+    WestHyphenAfricanCuisineCount,
+    NortheastCuisineCount,
+    TonganCuisineCount,
+    WestafricaCuisineCount,
+)
+from jstark.mealkit.cuisine_count import ZanzibarianCuisineCount, MidwestCuisineCount
 
 
 class MealkitFeatures(FeatureGenerator):
@@ -62,4 +183,86 @@ class MealkitFeatures(FeatureGenerator):
         AvgPurchaseCycle,
         Cuisines,
         CuisineCount,
+        ItalianCuisineCount,
+        FrenchCuisineCount,
+        SpanishCuisineCount,
+        SrilankanCuisineCount,
+        MalaysianCuisineCount,
+        AmericanCuisineCount,
+        AsianCuisineCount,
+        GermanCuisineCount,
+        CentralAmericaCuisineCount,
+        ArgentinianCuisineCount,
+        NorthAmericanCuisineCount,
+        NewZealandCuisineCount,
+        CanadianCuisineCount,
+        SwedishCuisineCount,
+        EgyptianCuisineCount,
+        NorthernEuropeanCuisineCount,
+        CajunCuisineCount,
+        AustrianCuisineCount,
+        MexicanCuisineCount,
+        MediterraneanCuisineCount,
+        ThaiCuisineCount,
+        ChineseCuisineCount,
+        LatinAmericanCuisineCount,
+        SouthAsiaCuisineCount,
+        MiddleEasternCuisineCount,
+        TraditionalCuisineCount,
+        SteakhouseCuisineCount,
+        PacificislandsCuisineCount,
+        EastAsiaCuisineCount,
+        BritishCuisineCount,
+        CaribbeanCuisineCount,
+        FilipinoCuisineCount,
+        TurkishCuisineCount,
+        BelgianCuisineCount,
+        SouthAmericanCuisineCount,
+        NorthAfricanCuisineCount,
+        SouthAfricanCuisineCount,
+        WestAfricanCuisineCount,
+        EastAfricanCuisineCount,
+        WesternEuropeanCuisineCount,
+        PortugueseCuisineCount,
+        PeruvianCuisineCount,
+        JapaneseCuisineCount,
+        PacificIslandsCuisineCount,
+        SouthernEuropeCuisineCount,
+        AfricanCuisineCount,
+        CentralAsiaCuisineCount,
+        NorthamericaCuisineCount,
+        EuropeanCuisineCount,
+        MoroccanCuisineCount,
+        AustralianCuisineCount,
+        HungarianCuisineCount,
+        IranianCuisineCount,
+        SoutheastAsiaCuisineCount,
+        HawaiianCuisineCount,
+        ScandinavianCuisineCount,
+        BrazilianCuisineCount,
+        IndonesianCuisineCount,
+        MongolianCuisineCount,
+        RussianCuisineCount,
+        SouthAsianCuisineCount,
+        BulgarianCuisineCount,
+        FusionCuisineCusiineCount,
+        IrishCuisineCount,
+        GeorgianCuisineCount,
+        SouthwestCuisineCount,
+        CambodianCuisineCount,
+        LatinCuisineCount,
+        CubanCuisineCount,
+        SoutheastCuisineCount,
+        SouthHyphenAfricanCuisineCount,
+        JamaicanCuisineCount,
+        IsrealiCuisineCount,
+        EasteuropeanCuisineCount,
+        SingaporeanCuisineCount,
+        NordicCuisineCount,
+        WestHyphenAfricanCuisineCount,
+        NortheastCuisineCount,
+        TonganCuisineCount,
+        WestafricaCuisineCount,
+        ZanzibarianCuisineCount,
+        MidwestCuisineCount,
     }

--- a/tests/test_mealkit_features.py
+++ b/tests/test_mealkit_features.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 import pytest
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 
 from jstark.mealkit.mealkit_features import MealkitFeatures
 
@@ -87,3 +87,40 @@ def test_cuisines(dataframe_of_faker_mealkit_orders: DataFrame):
     assert first["Cuisines_2q2"] == ["Italian", "French", "Spanish"]
     assert first["Cuisines_3q3"] == ["Italian", "French", "Spanish"]
     assert first["Cuisines_4q4"] == ["Italian", "French", "Spanish"]
+
+
+def test_cuisine(spark_session: SparkSession):
+    df = spark_session.createDataFrame(
+        [
+            ("Italian", datetime(2022, 1, 10, 1, 2, 3)),
+            ("Italian", datetime(2022, 1, 10, 1, 2, 3)),
+            ("Italian", datetime(2022, 1, 10, 1, 2, 3)),
+            ("French", datetime(2022, 1, 10, 1, 2, 3)),
+            ("French", datetime(2022, 1, 10, 1, 2, 3)),
+            ("Spanish", datetime(2022, 1, 10, 1, 2, 3)),
+        ],
+        ["cuisine", "timestamp"],
+    )
+    mf = MealkitFeatures(
+        as_at=date(2022, 2, 1),
+        feature_periods=["1m1"],
+        feature_stems=[
+            "ItalianCuisineCount",
+            "FrenchCuisineCount",
+            "SpanishCuisineCount",
+        ],
+    )
+    output_df = df.groupBy().agg(*mf.features)
+    assert (
+        output_df.schema["ItalianCuisineCount_1m1"].metadata["description"]
+        == "Count of Italian recipes between 2022-01-01 and 2022-01-31"
+    )
+    assert output_df.schema["ItalianCuisineCount_1m1"].metadata["commentary"] == (
+        "The number of Italian recipes. Typically the dataframe supplied to this "
+        + "feature will have many recipes for the same cuisine, this feature allows "
+        + "you to determine how many Italian recipes have been ordered."
+    )
+    first = output_df.first()
+    assert first["ItalianCuisineCount_1m1"] == 3
+    assert first["FrenchCuisineCount_1m1"] == 2
+    assert first["SpanishCuisineCount_1m1"] == 1


### PR DESCRIPTION
## Summary
- Add `CountIf` base feature class with `count_if` aggregator for conditional counting
- Add `CuisineCountIf` abstract class and ~90 concrete per-cuisine subclasses (e.g. `ItalianCuisineCount`, `MexicanCuisineCount`) that count rows matching a specific cuisine over configurable time periods
- Register all new cuisine features in `MealkitFeatures.FEATURE_CLASSES`

## Test plan
- [x] Added `test_cuisine` test verifying ItalianCuisineCount, FrenchCuisineCount, and SpanishCuisineCount produce correct counts
- [ ] Run full test suite with `uv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)