### PR TITLE
Replace python-dateutil with pendulum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,10 @@ repos:
   rev: v1.19.1
   hooks:
   - id: mypy
-    additional_dependencies: [types-python-dateutil]
+    additional_dependencies: []
     name: mypy jstark
     files: ^jstark
   - id: mypy
-    additional_dependencies: [types-python-dateutil]
+    additional_dependencies: []
     name: mypy tests
     files: ^tests

--- a/jstark/features/feature.py
+++ b/jstark/features/feature.py
@@ -6,9 +6,6 @@ All feature classes are derived from here
 from abc import ABCMeta, abstractmethod
 from datetime import date, timedelta, datetime
 from typing import Callable
-from dateutil.relativedelta import relativedelta
-
-
 from pyspark.sql import Column
 import pyspark.sql.functions as f
 import pendulum
@@ -89,13 +86,12 @@ class Feature(metaclass=ABCMeta):
 
     @property
     def start_date(self) -> date:
+        p_as_at = pendulum.date(self.as_at.year, self.as_at.month, self.as_at.day)
         n_days_ago = self.as_at - timedelta(days=self.feature_period.start)
         n_weeks_ago = self.as_at - timedelta(weeks=self.feature_period.start)
-        n_months_ago = self.as_at - relativedelta(months=self.feature_period.start)
-        n_quarters_ago = self.as_at - relativedelta(
-            months=self.feature_period.start * 3
-        )
-        n_years_ago = self.as_at - relativedelta(years=self.feature_period.start)
+        n_months_ago = p_as_at.subtract(months=self.feature_period.start)
+        n_quarters_ago = p_as_at.subtract(months=self.feature_period.start * 3)
+        n_years_ago = p_as_at.subtract(years=self.feature_period.start)
         match self.feature_period.period_unit_of_measure:
             case PeriodUnitOfMeasure.DAY:
                 return n_days_ago
@@ -112,11 +108,12 @@ class Feature(metaclass=ABCMeta):
 
     @property
     def end_date(self) -> date:
+        p_as_at = pendulum.date(self.as_at.year, self.as_at.month, self.as_at.day)
         n_days_ago = self.as_at - timedelta(days=self.feature_period.end)
         n_weeks_ago = self.as_at - timedelta(weeks=self.feature_period.end)
-        n_months_ago = self.as_at - relativedelta(months=self.feature_period.end)
-        n_quarters_ago = self.as_at - relativedelta(months=self.feature_period.end * 3)
-        n_years_ago = self.as_at - relativedelta(years=self.feature_period.end)
+        n_months_ago = p_as_at.subtract(months=self.feature_period.end)
+        n_quarters_ago = p_as_at.subtract(months=self.feature_period.end * 3)
+        n_years_ago = p_as_at.subtract(years=self.feature_period.end)
         match self.feature_period.period_unit_of_measure:
             case PeriodUnitOfMeasure.DAY:
                 last_day_of_period = n_days_ago

--- a/jstark/features/first_and_last_date_of_period.py
+++ b/jstark/features/first_and_last_date_of_period.py
@@ -4,7 +4,8 @@ Helper class for figuring out dates relative to a given date
 """
 
 from datetime import date, timedelta
-from dateutil.relativedelta import relativedelta
+
+import pendulum
 
 
 class FirstAndLastDateOfPeriod:
@@ -54,11 +55,10 @@ class FirstAndLastDateOfPeriod:
 
     @property
     def last_date_in_month(self) -> date:
-        return (
-            self._date_in_period
-            + relativedelta(months=1, day=1)
-            - relativedelta(days=1)
+        first_of_month = pendulum.date(
+            self._date_in_period.year, self._date_in_period.month, 1
         )
+        return first_of_month.add(months=1).subtract(days=1)
 
     @property
     def first_date_in_quarter(self) -> date:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
   "pendulum>=3.2.0",
   "pyspark>=3.5",
-  "python-dateutil",
 ]
 
 dynamic = ["version"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 import uuid
 from decimal import Decimal
 from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
-
-
+import pendulum
 import pytest
 from pyspark.sql import DataFrame, SparkSession, Row
 import pyspark.sql.functions as f
@@ -12,6 +10,12 @@ from jstark.grocery import GroceryFeatures
 from jstark.feature_period import FeaturePeriod, PeriodUnitOfMeasure
 from jstark.sample.transactions import FakeGroceryTransactions
 from jstark.sample.mealkit_orders import FakeMealkitOrders
+
+
+def _subtract_months(dt: datetime, months: int) -> datetime:
+    """Subtract months from a datetime using pendulum, returning a plain datetime."""
+    d = pendulum.date(dt.year, dt.month, dt.day).subtract(months=months)
+    return datetime(d.year, d.month, d.day, dt.hour, dt.minute, dt.second)
 
 
 @pytest.fixture(scope="session")
@@ -81,7 +85,7 @@ def dataframe_of_purchases(
     }
     transactions = [
         {
-            "Timestamp": as_at_timestamp - relativedelta(months=12),
+            "Timestamp": _subtract_months(as_at_timestamp, 12),
             "Customer": "Luke",
             "Store": "Ealing",
             "Channel": "Instore",
@@ -97,7 +101,7 @@ def dataframe_of_purchases(
             ],
         },
         {
-            "Timestamp": as_at_timestamp - relativedelta(months=2),
+            "Timestamp": _subtract_months(as_at_timestamp, 2),
             "Customer": "Luke",
             "Store": "Twickenham",
             "Channel": "Online",
@@ -113,7 +117,7 @@ def dataframe_of_purchases(
             ],
         },
         {
-            "Timestamp": as_at_timestamp - relativedelta(months=1),
+            "Timestamp": _subtract_months(as_at_timestamp, 1),
             "Customer": "Leia",
             "Store": "Ealing",
             "Channel": "Instore",
@@ -186,62 +190,62 @@ def dataframe_of_purchases(
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=3),
+            "Timestamp": _subtract_months(chew_car_timestamp, 3),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=5),
+            "Timestamp": _subtract_months(chew_car_timestamp, 5),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=6),
+            "Timestamp": _subtract_months(chew_car_timestamp, 6),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=9),
+            "Timestamp": _subtract_months(chew_car_timestamp, 9),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=10),
+            "Timestamp": _subtract_months(chew_car_timestamp, 10),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=12),
+            "Timestamp": _subtract_months(chew_car_timestamp, 12),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=13),
+            "Timestamp": _subtract_months(chew_car_timestamp, 13),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=15),
+            "Timestamp": _subtract_months(chew_car_timestamp, 15),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=16),
+            "Timestamp": _subtract_months(chew_car_timestamp, 16),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=17),
+            "Timestamp": _subtract_months(chew_car_timestamp, 17),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=18),
+            "Timestamp": _subtract_months(chew_car_timestamp, 18),
         },
         {
             **chew_car,
             "Basket": uuid.uuid4(),
-            "Timestamp": chew_car_timestamp - relativedelta(months=21),
+            "Timestamp": _subtract_months(chew_car_timestamp, 21),
         },
     ]
     flattened_transactions = FakeGroceryTransactions.flatten_transactions(transactions)

--- a/tests/test_feature_period.py
+++ b/tests/test_feature_period.py
@@ -1,7 +1,6 @@
 from platform import python_version
 from datetime import date, datetime, timedelta
-from dateutil.relativedelta import relativedelta
-
+import pendulum
 import pytest
 from packaging import version
 from pyspark.sql import DataFrame
@@ -292,7 +291,7 @@ def test_last_month(luke_and_leia_purchases: DataFrame):
     assert {
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
-    } == {date.today().replace(day=1) - relativedelta(months=1)}
+    } == {pendulum.date(date.today().year, date.today().month, 1).subtract(months=1)}
 
 
 def test_this_quarter(luke_and_leia_purchases: DataFrame):
@@ -318,21 +317,21 @@ def test_last_quarter(luke_and_leia_purchases: DataFrame):
     df = luke_and_leia_purchases.groupBy().agg(*gf.features)
     match date.today().month:
         case 1 | 2 | 3:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=1
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 1, 1).subtract(
+                months=3
+            )
         case 4 | 5 | 6:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=4
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 4, 1).subtract(
+                months=3
+            )
         case 7 | 8 | 9:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=7
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 7, 1).subtract(
+                months=3
+            )
         case _:  # all other months:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=10
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 10, 1).subtract(
+                months=3
+            )
     assert {
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
@@ -354,7 +353,7 @@ def test_last_year(luke_and_leia_purchases: DataFrame):
     assert {
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
-    } == {date.today().replace(day=1).replace(month=1) - relativedelta(years=1)}
+    } == {pendulum.date(date.today().year, 1, 1).subtract(years=1)}
 
 
 def test_this_month_vs_one_year_prior(luke_and_leia_purchases: DataFrame):
@@ -365,19 +364,20 @@ def test_this_month_vs_one_year_prior(luke_and_leia_purchases: DataFrame):
         for c in df.schema
     } == {
         date.today().replace(day=1),
-        date.today().replace(day=1) - relativedelta(years=1),
+        pendulum.date(date.today().year, date.today().month, 1).subtract(years=1),
     }
 
 
 def test_last_month_vs_one_year_prior(luke_and_leia_purchases: DataFrame):
     gf = GroceryFeatures(**LAST_MONTH_VS_ONE_YEAR_PRIOR, feature_stems={"BasketCount"})  # type: ignore[arg-type]
     df = luke_and_leia_purchases.groupBy().agg(*gf.features)
+    today_first = pendulum.date(date.today().year, date.today().month, 1)
     assert {
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
     } == {
-        date.today().replace(day=1) - relativedelta(months=1),
-        date.today().replace(day=1) - relativedelta(months=1) - relativedelta(years=1),
+        today_first.subtract(months=1),
+        today_first.subtract(months=1).subtract(years=1),
     }
 
 
@@ -401,7 +401,9 @@ def test_this_quarter_vs_one_year_prior(luke_and_leia_purchases: DataFrame):
         for c in df.schema
     } == {
         first_day_of_quarter,
-        first_day_of_quarter - relativedelta(years=1),
+        pendulum.date(
+            first_day_of_quarter.year, first_day_of_quarter.month, 1
+        ).subtract(years=1),
     }
 
 
@@ -413,27 +415,29 @@ def test_last_quarter_vs_one_year_prior(luke_and_leia_purchases: DataFrame):
     df = luke_and_leia_purchases.groupBy().agg(*gf.features)
     match date.today().month:
         case 1 | 2 | 3:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=1
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 1, 1).subtract(
+                months=3
+            )
         case 4 | 5 | 6:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=4
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 4, 1).subtract(
+                months=3
+            )
         case 7 | 8 | 9:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=7
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 7, 1).subtract(
+                months=3
+            )
         case _:  # all other months:
-            first_day_of_quarter = date.today().replace(day=1).replace(
-                month=10
-            ) - relativedelta(months=3)
+            first_day_of_quarter = pendulum.date(date.today().year, 10, 1).subtract(
+                months=3
+            )
     assert {
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
     } == {
         first_day_of_quarter,
-        first_day_of_quarter - relativedelta(years=1),
+        pendulum.date(
+            first_day_of_quarter.year, first_day_of_quarter.month, 1
+        ).subtract(years=1),
     }
 
 
@@ -444,9 +448,9 @@ def test_last_five_years(luke_and_leia_purchases: DataFrame):
         datetime.strptime(c.metadata["start-date"], "%Y-%m-%d").date()
         for c in df.schema
     } == {
-        date.today().replace(day=1).replace(month=1) - relativedelta(years=1),
-        date.today().replace(day=1).replace(month=1) - relativedelta(years=2),
-        date.today().replace(day=1).replace(month=1) - relativedelta(years=3),
-        date.today().replace(day=1).replace(month=1) - relativedelta(years=4),
-        date.today().replace(day=1).replace(month=1) - relativedelta(years=5),
+        pendulum.date(date.today().year, 1, 1).subtract(years=1),
+        pendulum.date(date.today().year, 1, 1).subtract(years=2),
+        pendulum.date(date.today().year, 1, 1).subtract(years=3),
+        pendulum.date(date.today().year, 1, 1).subtract(years=4),
+        pendulum.date(date.today().year, 1, 1).subtract(years=5),
     }

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,6 @@ source = { editable = "." }
 dependencies = [
     { name = "pendulum" },
     { name = "pyspark" },
-    { name = "python-dateutil" },
 ]
 
 [package.optional-dependencies]
@@ -447,7 +446,6 @@ requires-dist = [
     { name = "faker", marker = "extra == 'faker'", specifier = ">=40.0.0" },
     { name = "pendulum", specifier = ">=3.2.0" },
     { name = "pyspark", specifier = ">=3.5" },
-    { name = "python-dateutil" },
 ]
 provides-extras = ["faker"]
 


### PR DESCRIPTION
## Summary
- Replaced all `dateutil.relativedelta` usage with pendulum's `subtract()`/`add()` methods in production code (`feature.py`, `first_and_last_date_of_period.py`)
- Updated test files (`conftest.py`, `test_feature_period.py`) to use pendulum for date arithmetic while preserving test logic
- Removed `python-dateutil` as a direct dependency from `pyproject.toml` and `types-python-dateutil` from `.pre-commit-config.yaml`

## Test plan
- [x] All 170 tests pass
- [x] All pre-commit hooks pass (ruff, mypy, ruff-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)