### PR TITLE
feat: add Allergens and AllergenCount mealkit features

### DIFF
--- a/jstark/mealkit/allergen_count.py
+++ b/jstark/mealkit/allergen_count.py
@@ -1,0 +1,24 @@
+"""AllergenCount feature"""
+
+import pyspark.sql.functions as f
+from pyspark.sql import Column
+
+from jstark.features.distinctcount_feature import DistinctCount
+
+
+class AllergenCount(DistinctCount):
+    def column_expression(self) -> Column:
+        return f.col("Allergen")
+
+    @property
+    def description_subject(self) -> str:
+        return "Distinct count of Allergens"
+
+    @property
+    def commentary(self) -> str:
+        return (
+            "The number of allergens. Typically the dataframe supplied "
+            + "to this feature will have many recipes for the same allergen, "
+            + "this feature allows you to determine how many distinct allergens "
+            + "have been ordered."
+        )

--- a/jstark/mealkit/allergens.py
+++ b/jstark/mealkit/allergens.py
@@ -1,0 +1,24 @@
+"""Allergens feature"""
+
+import pyspark.sql.functions as f
+from pyspark.sql import Column
+
+from jstark.features.collect_set_feature import CollectSet
+
+
+class Allergens(CollectSet):
+    def column_expression(self) -> Column:
+        return f.col("Allergen")
+
+    @property
+    def description_subject(self) -> str:
+        return "Set of Allergens"
+
+    @property
+    def commentary(self) -> str:
+        return (
+            "The set of allergens. Typically the dataframe supplied "
+            + "to this feature will have many recipes for the same allergen, "
+            + "this feature allows you to determine the set of allergens "
+            + "that have been ordered."
+        )

--- a/jstark/mealkit/mealkit_features.py
+++ b/jstark/mealkit/mealkit_features.py
@@ -21,6 +21,8 @@ from jstark.features.feature import Feature
 from jstark.feature_generator import FeatureGenerator
 from jstark.mealkit.average_quantity_per_order import AvgQuantityPerOrder
 from jstark.mealkit.cycles_since_last_order import CyclesSinceLastOrder
+from jstark.mealkit.allergens import Allergens
+from jstark.mealkit.allergen_count import AllergenCount
 from jstark.mealkit.average_purchase_cycle import AvgPurchaseCycle
 from jstark.mealkit.cuisines import Cuisines
 from jstark.mealkit.cuisine_count import CuisineCount
@@ -159,6 +161,8 @@ class MealkitFeatures(FeatureGenerator):
         AvgQuantityPerOrder,
         CyclesSinceLastOrder,
         AvgPurchaseCycle,
+        Allergens,
+        AllergenCount,
         Cuisines,
         CuisineCount,
         # All of the following are counts for a specific cuisine

--- a/jstark/sample/mealkit_orders.py
+++ b/jstark/sample/mealkit_orders.py
@@ -31,6 +31,7 @@ class FakeMealkitOrders:
                 StructField("Product", StringType(), True),
                 StructField("Recipe", StringType(), True),
                 StructField("Cuisine", StringType(), True),
+                StructField("Allergen", StringType(), True),
                 StructField("Quantity", IntegerType(), True),
                 StructField("Order", StringType(), True),
                 StructField("Discount", DecimalType(10, 2), True),
@@ -44,6 +45,7 @@ class FakeMealkitOrders:
                 "Customer": d["Customer"],
                 "Product": d["Product"],
                 "Cuisine": d["Cuisine"],
+                "Allergen": d["Allergen"],
                 "Order": d["Order"],
                 "Timestamp": d["Timestamp"],
                 **d2,
@@ -92,6 +94,16 @@ class FakeMealkitOrders:
             ],
         )
 
+        allergens_provider = DynamicProvider(
+            provider_name="allergen",
+            elements=[
+                "Gluten",
+                "Eggs",
+                "Milk",
+                "Soy",
+            ],
+        )
+
         fake = Faker()
         if self.seed:
             Faker.seed(self.seed)
@@ -104,6 +116,9 @@ class FakeMealkitOrders:
 
         cuisines_fake = Faker()
         cuisines_fake.add_provider(cuisines_provider)
+
+        allergens_fake = Faker()
+        allergens_fake.add_provider(allergens_provider)
 
         mealkit_orders = []
 
@@ -137,6 +152,7 @@ class FakeMealkitOrders:
                     "Order": str(uuid.uuid4()),
                     "Product": products_fake.product(),
                     "Cuisine": cuisines_fake.cuisine(),
+                    "Allergen": allergens_fake.allergen(),
                     "Recipes": recipes,
                     "Discount": Decimal(random.uniform(0, 5)),
                 }

--- a/tests/test_mealkit_features.py
+++ b/tests/test_mealkit_features.py
@@ -25,6 +25,48 @@ def test_orderweeks(
     assert first["OrderCount_52w0"] == 903
 
 
+def test_allergens(dataframe_of_faker_mealkit_orders: DataFrame):
+    mf = MealkitFeatures(
+        as_at=date(2022, 1, 1),
+        feature_periods=["1q1", "2q2", "3q3", "4q4"],
+        feature_stems=["Allergens"],
+    )
+    output_df = dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)
+    assert output_df.columns == [
+        "Allergens_1q1",
+        "Allergens_2q2",
+        "Allergens_3q3",
+        "Allergens_4q4",
+    ]
+    first = output_df.first()
+    assert first is not None
+    assert set(first["Allergens_1q1"]) == {"Gluten", "Eggs", "Milk", "Soy"}
+    assert set(first["Allergens_2q2"]) == {"Gluten", "Eggs", "Milk", "Soy"}
+    assert set(first["Allergens_3q3"]) == {"Gluten", "Eggs", "Milk", "Soy"}
+    assert set(first["Allergens_4q4"]) == {"Gluten", "Eggs", "Milk", "Soy"}
+
+
+def test_allergen_count(dataframe_of_faker_mealkit_orders: DataFrame):
+    mf = MealkitFeatures(
+        as_at=date(2022, 1, 1),
+        feature_periods=["1q1", "2q2", "3q3", "4q4"],
+        feature_stems=["AllergenCount"],
+    )
+    output_df = dataframe_of_faker_mealkit_orders.groupBy().agg(*mf.features)
+    assert output_df.columns == [
+        "AllergenCount_1q1",
+        "AllergenCount_2q2",
+        "AllergenCount_3q3",
+        "AllergenCount_4q4",
+    ]
+    first = output_df.first()
+    assert first is not None
+    assert first["AllergenCount_1q1"] == 4
+    assert first["AllergenCount_2q2"] == 4
+    assert first["AllergenCount_3q3"] == 4
+    assert first["AllergenCount_4q4"] == 4
+
+
 def test_as_at_timestamp(dataframe_of_faker_mealkit_orders: DataFrame):
     """
     We had a situation where as_at was being passed as a datetime (which we support)


### PR DESCRIPTION
## Summary
- Adds `Allergens` (collect set) and `AllergenCount` (distinct count) mealkit features
- Adds an `Allergen` field to sample mealkit orders, seeded via a Faker dynamic provider
- Adds tests covering both features across quarterly feature periods (`1q1`..`4q4`)

## Test plan
- [ ] `uv run pytest` passes
- [ ] `uv run pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=jstark --cov=tests` maintains coverage
- [ ] `uv run pylint --rcfile .github/linters/pylintrc jstark tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)